### PR TITLE
Add songs to the play queue

### DIFF
--- a/dependencies.cfg
+++ b/dependencies.cfg
@@ -3,4 +3,4 @@
 #   name: dependency name
 #   separator: colon + optional white space
 #   version: git branch or tag
-integrations.library: v0.5.0
+integrations.library: v0.5.1

--- a/src/spotify.cpp
+++ b/src/spotify.cpp
@@ -241,7 +241,7 @@ void Spotify::search(QString query, QString type, QString limit, QString offset)
             if (map.contains("tracks")) {
                 QVariantList map_tracks = map.value("tracks").toMap().value("items").toList();
 
-                QStringList commands = {"PLAY", "SONGRADIO"};
+                QStringList commands = {"PLAY", "SONGRADIO", "QUEUE"};
 
                 for (int i = 0; i < map_tracks.length(); i++) {
                     QString id       = map_tracks[i].toMap().value("id").toString();
@@ -311,7 +311,7 @@ void Spotify::search(QString query, QString type, QString limit, QString offset)
             if (map.contains("playlists")) {
                 QVariantList map_playlists = map.value("playlists").toMap().value("items").toList();
 
-                QStringList commands = {"PLAY", "PLAYLISTRADIO"};
+                QStringList commands = {"PLAY", "PLAYLISTRADIO", "QUEUE"};
 
                 for (int i = 0; i < map_playlists.length(); i++) {
                     QString id       = map_playlists[i].toMap().value("id").toString();
@@ -387,7 +387,7 @@ void Spotify::getAlbum(QString id) {
                 }
             }
 
-            QStringList commands = {"PLAY", "SONGRADIO"};
+            QStringList commands = {"PLAY", "SONGRADIO", "QUEUE"};
 
             BrowseModel* album = new BrowseModel(nullptr, id, title, subtitle, type, image, commands);
 
@@ -436,7 +436,7 @@ void Spotify::getPlaylist(QString id) {
                 }
             }
 
-            QStringList commands = {"PLAY", "SONGRADIO"};
+            QStringList commands = {"PLAY", "SONGRADIO", "QUEUE"};
 
             BrowseModel* album = new BrowseModel(nullptr, id, title, subtitle, type, image, commands);
 
@@ -682,6 +682,23 @@ void Spotify::sendCommand(const QString& type, const QString& entityId, int comm
                                      });
                     getRequest(url, param.toMap().value("id").toString());
                 }
+            }
+        }
+    } else if (command == MediaPlayerDef::C_QUEUE) {
+        if (param.toMap().contains("type")) {
+            if (param.toMap().value("type").toString() == "track") {
+                QString  url     = "/v1/tracks/";
+                QObject* context = new QObject(this);
+                QObject::connect(this, &Spotify::requestReady, context,
+                                 [=](const QVariantMap& map, const QString& rUrl) {
+                                     if (rUrl == url) {
+                                         qCDebug(m_logCategory) << "QUEUE MEDIA" << map.value("uri").toString();
+                                         QString message = "?uri=" + map.value("uri").toString();
+                                         postRequest("/v1/me/player/queue", message);
+                                     }
+                                     context->deleteLater();
+                                 });
+                getRequest(url, param.toMap().value("id").toString());
             }
         }
     } else if (command == MediaPlayerDef::C_PAUSE) {


### PR DESCRIPTION
Hi,

This PR adds the "Add to queue" command to the list of commands for a single track. In order for this to function I also had to add the `addToQueue` extension to the media player entity in the *YIO-Remote/remote-software* repository. There's a PR open there as well: https://github.com/YIO-Remote/remote-software/pull/497

My first code related contribution and even though it's not a lot of code I'd highly appreciate feedback if there's something that could have been done better!

![2020-08-11_16-12-33](https://user-images.githubusercontent.com/16165462/89908126-d1b12100-dbed-11ea-9a1b-f28bbe467366.png)